### PR TITLE
Migrate from rest to GraphQL

### DIFF
--- a/src/components/PullRequestItem.tsx
+++ b/src/components/PullRequestItem.tsx
@@ -129,9 +129,6 @@ export const PullRequestItem = observer(
 );
 
 function itemBgColor(pr: EnrichedPullRequest): string {
-  if (pr.isMerged) {
-    return "#CBC3E3";
-  }
   if (pr.draft) {
     return "#fff";
   }

--- a/src/github-api/api.ts
+++ b/src/github-api/api.ts
@@ -1,6 +1,6 @@
-import { PaginationResults } from "@octokit/plugin-paginate-rest/dist-types/types";
 import { Octokit } from "@octokit/rest";
 import { GetResponseDataTypeFromEndpointMethod } from "@octokit/types";
+import { PullRequestRet } from "./implementation";
 
 /**
  * A simple wrapper around GitHub's API.
@@ -13,62 +13,10 @@ export interface GitHubApi {
     GetResponseDataTypeFromEndpointMethod<Octokit["users"]["getAuthenticated"]>
   >;
 
-  /**
-   * Returns the full list of pull requests matching a given query.
-   */
-  searchPullRequests(query: string): Promise<
-    // Note: There might be a more efficient way to represent this type.
-    PaginationResults<
-      GetResponseDataTypeFromEndpointMethod<
-        Octokit["search"]["issuesAndPullRequests"]
-      >["items"][number]
-    >
-  >;
-
-  loadPullRequestChangeSummary(pr: PullRequestReference): Promise<any>;
-
-  /**
-   * Returns the details of a pull request.
-   */
-  loadPullRequestDetails(
-    pr: PullRequestReference
-  ): Promise<GetResponseDataTypeFromEndpointMethod<Octokit["pulls"]["get"]>>;
-
-  /**
-   * Returns the full list of reviews for a pull request.
-   */
-  loadReviews(
-    pr: PullRequestReference
-  ): Promise<
-    GetResponseDataTypeFromEndpointMethod<Octokit["pulls"]["listReviews"]>
-  >;
-
-  /**
-   * Returns the full list of comments for a pull request.
-   */
-  loadComments(
-    pr: PullRequestReference
-  ): Promise<
-    GetResponseDataTypeFromEndpointMethod<Octokit["issues"]["listComments"]>
-  >;
-
-  /**
-   * Returns the full list of comments for a pull request.
-   */
-  loadReviewComments(
-    pr: PullRequestReference
-  ): Promise<
-    GetResponseDataTypeFromEndpointMethod<
-      Octokit["pulls"]["listReviewComments"]
-    >
-  >;
-
-  /**
-   * Returns the current status fields for a pull request.
-   */
-  loadPullRequestStatus(pr: PullRequestReference): Promise<PullRequestStatus>;
-
-  loadIsMerged(pr: PullRequestReference): Promise<boolean>;
+  loadMyMergedPullRequests(): Promise<PullRequestRet>;
+  loadMyOpenPullRequests(): Promise<PullRequestRet>;
+  loadNeedsRevisionPullRequests(): Promise<PullRequestRet>;
+  loadToReviewPullRequests(): Promise<PullRequestRet>;
 }
 
 // Ref: https://docs.github.com/en/graphql/reference/enums#pullrequestreviewdecision


### PR DESCRIPTION
I'm seeing more errors about rate limits.  So let's move to GraphQL so that we can request exactly what we need and do it in significantly less queries (now 4)